### PR TITLE
#6 全商品取得のAPI仕様追加

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    // use code formatter for Prisma
+    "Prisma.prisma"
+  ]
+}

--- a/src/openapi/components/responses/items/200Success.yaml
+++ b/src/openapi/components/responses/items/200Success.yaml
@@ -1,0 +1,5 @@
+description: Success
+content:
+  application/json:
+    schema:
+      $ref: "../../schemas/items/items.yaml"

--- a/src/openapi/components/responses/items/404NotFoundItems.yaml
+++ b/src/openapi/components/responses/items/404NotFoundItems.yaml
@@ -1,0 +1,10 @@
+description: Items Not Found
+content:
+  application/json:
+    schema:
+      $ref: "../../schemas/common/404NotFound.yaml"
+    examples:
+      itemsNotFound:
+        value:
+          code: "404"
+          message: "商品が見つかりませんでした。"

--- a/src/openapi/components/schemas/common/400BadRequest.yaml
+++ b/src/openapi/components/schemas/common/400BadRequest.yaml
@@ -1,0 +1,9 @@
+titel: Bad Request
+type: object
+description: 400Error Response
+properties:
+  code: { type: string, example: "400" }
+  message: { type: string, example: "リクエストが不正です。" }
+required:
+  - code
+  - message

--- a/src/openapi/components/schemas/common/404NotFound.yaml
+++ b/src/openapi/components/schemas/common/404NotFound.yaml
@@ -1,0 +1,9 @@
+title: Not Found
+type: object
+description: 404Error Response
+properties:
+  code: { type: string, example: "404" }
+  message: { type: string, example: "リソースが見つかりませんでした。" }
+required:
+  - code
+  - message

--- a/src/openapi/components/schemas/items/item.yaml
+++ b/src/openapi/components/schemas/items/item.yaml
@@ -1,0 +1,12 @@
+type: object
+description: 商品
+required:
+  - item_id
+properties:
+  id: { type: string, example: 商品ID }
+  item_name: { type: string, example: 商品名 }
+  stock: { type: boolean, example: 在庫 }
+  purchaser_id: { type: string, example: 購入者ID }
+  description: { type: string, example: 説明 }
+  main_image_url: { type: string, example: メイン画像URL }
+  purchased_at: { type: string, example: 購入日時 }

--- a/src/openapi/components/schemas/items/items.yaml
+++ b/src/openapi/components/schemas/items/items.yaml
@@ -1,0 +1,3 @@
+type: array
+items:
+  $ref: "../../schemas/items/item.yaml"

--- a/src/openapi/openapi.yaml
+++ b/src/openapi/openapi.yaml
@@ -1,0 +1,13 @@
+openapi: 3.1.0
+info:
+  title: みかたんにってぃんぐAPI
+  version: "1.0"
+  description: アプリケーションのAPI仕様書です
+  contact:
+    name: Daichi Sugiyama
+paths:
+  /items:
+    $ref: "paths/item/items.yaml"
+tags:
+  - name: items
+    description: 商品に関するAPI群

--- a/src/openapi/paths/item/items.yaml
+++ b/src/openapi/paths/item/items.yaml
@@ -1,0 +1,32 @@
+get:
+  summary: 商品一覧取得API
+  operationId: get.items.index
+  description: 全件検索で商品の一覧を取得する。商品が存在しない場合は空の配列を返却する。
+  tags:
+    - items
+  parameters:
+    - name: stock
+      in: query
+      required: false
+      schema:
+        type: string
+        enum: ["only", "all"]
+      description: 商品在庫の有無検索。onlyは在庫ありのみ、allは在庫なしを含む全件。
+      examples:
+        only:
+          value: only
+          summary: 在庫ありのみ
+        all:
+          value: all
+          summary: 在庫なしを含む全件
+  responses:
+    "200":
+      $ref: "../../components/responses/items/200Success.yaml"
+    "400":
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/common/400BadRequest.yaml"
+    "404":
+      $ref: "../../components/responses/items/404NotFoundItems.yaml"

--- a/src/prisma/migrations/20250113062156_add_item_main_image_url_column/migration.sql
+++ b/src/prisma/migrations/20250113062156_add_item_main_image_url_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "items" ADD COLUMN     "main_image_url" VARCHAR(255);

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -21,22 +21,23 @@ model User {
   created_at DateTime  @default(now())
   updated_at DateTime?
 
-  items      Item[]
+  items Item[]
 
   @@map("users")
 }
 
 model Item {
-  id           String    @id @default(uuid()) @db.Char(36)
-  item_name    String    @db.VarChar(255)
-  stock        Boolean   @default(true)
-  purchaser_id String?   @db.Char(36)
-  description  String?   @db.VarChar(255)
-  purchased_at DateTime?
-  created_at   DateTime  @default(now())
-  updated_at   DateTime?
+  id             String    @id @default(uuid()) @db.Char(36)
+  item_name      String    @db.VarChar(255)
+  stock          Boolean   @default(true)
+  purchaser_id   String?   @db.Char(36)
+  description    String?   @db.VarChar(255)
+  main_image_url String?   @db.VarChar(255)
+  purchased_at   DateTime?
+  created_at     DateTime  @default(now())
+  updated_at     DateTime?
 
-  Purchaser     User?    @relation(fields: [purchaser_id], references: [id])
+  purchaser User? @relation(fields: [purchaser_id], references: [id])
 
   @@map("items")
 }


### PR DESCRIPTION
close #6 
- #8 を先に対応するため本issueではAPI実装は行わず、仕様のみ記述するに留める
- 実装issueは別途切り直す

## 対応
- OpenAPI仕様を追記
- prisma用フォーマッターを追加
- 商品メイン画像のスキーマ定義を追記